### PR TITLE
Fix cross-site scripting vulnerability - /quiz/technology/?id=15

### DIFF
--- a/tromsite/Quiz/quiz.php
+++ b/tromsite/Quiz/quiz.php
@@ -36,5 +36,5 @@
 
   // If, for some reason 'quiz id' is processed somewhere else on the code,
   // make sure to use htmlspecialchars before displaying its contents to the DOM.
-  echo '<input type="hidden" id="quizId" value="'. htmlspecialchars($id) .'">';
+  echo '<input id="quizId" type="hidden" value="'. htmlspecialchars($id) .'">';
 ?>

--- a/tromsite/Quiz/quiz.php
+++ b/tromsite/Quiz/quiz.php
@@ -1,23 +1,40 @@
 <?php
-$ids = array(59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,117,118,119,120,121,122,123,124,125,126,127);
+  $ids = array(59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,117,118,119,120,121,122,123,124,125,126,127);
 
-echo '<div id="quizMessage"></div>';
+  echo '<div id="quizMessage"></div>';
 
-if(isset($_GET["id"])) {
-    $id = $_GET["id"];
-} else {
-    $answeredIds = explode(',', $_COOKIE['answeredIds']);
-    $unansweredIds = array_diff($ids, $answeredIds);
-    //var\_dump(implode(',', $unansweredIds));
-    $id = $unansweredIds[array_rand($unansweredIds)];
-}
+  if(isset($_GET["id"])) {
+      // Escape user input for HTML tags and cast to integer
+      $id = (int) htmlspecialchars($_GET["id"]);
+  } else {
+      // Check if the 'answeredIds' cookie is present on the user's session
+      if(!isset($_COOKIE['answeredIds'])){
+        // If the cookie value is empty, initialize an empty '$answeredIds' array
+        $answeredIds = [];
+      } else {
+        // Otherwise, get the correct user answers via the 'answeredIds' cookie.
+        $answeredIds = explode(',', $_COOKIE['answeredIds']);
+      }
 
-//echo 'ID: '.$id; // display the quiz id
+      // Get the unanswered questions ids by calculating the difference between the two arrays, '$answeredIds' and '$ids'.
+      $unansweredIds = array_diff($ids, $answeredIds);
 
-if(!isset($id))
-    $id = '-1';
-else
-    echo do_shortcode('[viralQuiz id='.$id.']');
+      // Debug line
+      //var\_dump(implode(',', $unansweredIds));
 
-echo '<input type="hidden" id="quizId" value="'.$id.'">';
+      // Finally, set the quiz id to a pseudo-randomly selected value from the '$unansweredIds' array that was calculated earlier.
+      $id = $unansweredIds[array_rand($unansweredIds)];
+  }
+
+  // Debug line
+  //echo 'ID: '.$id; // Display the quiz id
+
+  if(!isset($id))
+      $id = '-1';
+  else
+      echo do_shortcode('[viralQuiz id='.htmlspecialchars($id).']'); // Wordpress function call
+
+  // If, for some reason 'quiz id' is processed somewhere else on the code,
+  // make sure to use htmlspecialchars before displaying its contents to the DOM.
+  echo '<input type="hidden" id="quizId" value="'. htmlspecialchars($id) .'">';
 ?>


### PR DESCRIPTION
This pull request aims to fix a cross-site scripting vulnerability affecting the quiz id parameter under '`/quiz/technology/?id=`'.
It does so by utilizing a PHP built-in function, `htmlspecialchars()` to escape any HTML content from the parameter and later type casting the value to integer.

Also, it applies a check to determine if there is such cookie named '`answeredIds`' on the user's session in order to utilize the appropriate array accordingly. 

I would like to ask you guys, @ZiadJ and @tiotrom, please, review the changes to the code and request any necessary modifications.